### PR TITLE
:sparkles: update action to release

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -88,13 +88,28 @@ jobs:
           path: "vscode/*.vsix"
 
       # Update latest release (only on Linux and for main branch)
-      - name: Update latest release
-        if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
-        uses: marvinpinto/action-automatic-releases@latest
+      # - name: Update latest release
+      #   if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
+      #   uses: marvinpinto/action-automatic-releases@latest
+      #   with:
+      #     repo_token: "${{secrets.GITHUB_TOKEN}}"
+      #     automatic_release_tag: "latest"
+      #     prerelease: true
+      #     title: "Development Build"
+      #     files: |
+      #       *.vsix
+
+      - name: Create or Update Pre-release
+        if: matrix.arch == 'linux' && github.ref == 'refs/heads/main'
+        uses: ncipollo/release-action@v1
         with:
-          repo_token: "${{secrets.GITHUB_TOKEN}}"
-          automatic_release_tag: "latest"
+          tag: latest
+          releaseName: "Development Build - ${{ github.sha }}"
+          allowUpdates: true
+          overwrite: true
+          forceUpdateTag: true
+          commit: ${{ github.sha }}
+          artifacts: "vscode/*.vsix"
           prerelease: true
-          title: "Development Build"
-          files: |
-            *.vsix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
