### PR TITLE
:bug: updating tag name

### DIFF
--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -87,24 +87,19 @@ jobs:
           name: vscode-extension-${{ matrix.arch }}-${{ github.run_id }}
           path: "vscode/*.vsix"
 
-      # Update latest release (only on Linux and for main branch)
-      # - name: Update latest release
-      #   if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
-      #   uses: marvinpinto/action-automatic-releases@latest
-      #   with:
-      #     repo_token: "${{secrets.GITHUB_TOKEN}}"
-      #     automatic_release_tag: "latest"
-      #     prerelease: true
-      #     title: "Development Build"
-      #     files: |
-      #       *.vsix
+      - name: Generate tag name
+        id: vars
+        shell: bash
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-8)
+          TAG_NAME="dev-${SHORT_SHA}"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
 
       - name: Create or Update Pre-release
         if: matrix.arch == 'linux' && github.ref == 'refs/heads/main'
         uses: ncipollo/release-action@v1
         with:
-          tag: latest
-          name: "Development Build - ${{ github.sha }}"
+          tag: ${{ steps.vars.outputs.tag_name }}
           allowUpdates: true
           commit: ${{ github.sha }}
           artifacts: "vscode/*.vsix"


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
