### PR TITLE
:seedling: adding prerelease artifacts pruning

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,42 @@
+name: Prune Nightly Pre-releases
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # Runs every day at 6:00am UTC
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: List releases
+        id: list_releases
+        run: |
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/${{ github.repository }}/releases \
+          | jq '[.[] | select(.prerelease == true)]' > prereleases.json
+
+      - name: Prune old pre-releases
+        run: |
+          current_date=$(date +%s)
+          
+          jq -c '.[]' prereleases.json | while read prerelease; do
+            release_date=$(echo $prerelease | jq -r '.created_at')
+            release_id=$(echo $prerelease | jq -r '.id')
+
+            release_timestamp=$(date --date="$release_date" +%s)
+            
+            age_in_days=$(( (current_date - release_timestamp) / 86400 ))
+            
+            if [ $age_in_days -gt 1 ]; then
+              echo "Deleting prerelease $release_id (created at $release_date)"
+              curl -X DELETE \
+                   -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                   -H "Accept: application/vnd.github.v3+json" \
+                   https://api.github.com/repos/${{ github.repository }}/releases/$release_id
+            fi
+          done


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
