### PR TITLE
:bug: restructure steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,15 +81,7 @@ jobs:
           npm install @vscode/vsce
           npx vsce package
 
-      - name: Rename VSIX Package
-        run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            mv vscode/*.vsix ./artifacts/konveyor-linux-${{ steps.get_version.outputs.version }}.vsix
-          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            mv vscode/*.vsix ./artifacts/konveyor-macos-${{ steps.get_version.outputs.version }}.vsix
-          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            mv vscode/*.vsix ./artifacts/konveyor-windows-${{ steps.get_version.outputs.version }}.vsix
-          fi
+
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
@@ -109,6 +101,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: vscode-extension-*
+      
+      - name: Rename VSIX Package
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            mv vscode/*.vsix ./artifacts/konveyor-linux-${{ steps.get_version.outputs.version }}.vsix
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            mv vscode/*.vsix ./artifacts/konveyor-macos-${{ steps.get_version.outputs.version }}.vsix
+          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            mv vscode/*.vsix ./artifacts/konveyor-windows-${{ steps.get_version.outputs.version }}.vsix
+          fi
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
