### PR TITLE
:bug: troubleshoot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,13 +136,13 @@ jobs:
       # Reuse Konveyor changelog
       - name: Generate Changelog
         id: changelog
-        uses: konveyor/release-tools/create-release@main
+        uses: savitharaghunathan/release-tools/create-release@main
         with:
           version: ${{ needs.release_prereq.outputs.tag_name }}
           prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
           repository: ${{ github.repository }}
           ref: ${{ github.sha }}
-          skip_release: true
+          skip_release: 'true'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
