### PR TITLE
:bug: Add changelog1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,8 @@ jobs:
       prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Final Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       tag_name:
         description: 'Enter Tag for the release'
         required: true
-
       prerelease:
         description: 'Is this a pre-release?'
         required: true
@@ -31,7 +30,7 @@ jobs:
             arch: windows
       max-parallel: 3
     outputs:
-      tag_name: ${{ steps.determine_tag.outputs.tag_name }}  
+      tag_name: ${{ steps.determine_tag.outputs.tag_name }}
 
     steps:
       - name: Checkout code
@@ -55,18 +54,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Run tests on Linux
+      # Run tests on different OSes
       - name: Run tests (Linux)
         if: matrix.arch == 'linux'
-        run: 
-          xvfb-run -a npm run test
+        run: xvfb-run -a npm run test
 
-      # Run tests on macOS
       - name: Run tests (macOS)
         if: matrix.arch == 'macos'
         run: npm test
 
-      # Run tests on Windows
       - name: Run tests (Windows)
         if: matrix.arch == 'windows'
         shell: cmd
@@ -87,13 +83,31 @@ jobs:
           name: vscode-extension-${{ matrix.arch }}
           path: ./vscode/*.vsix
 
+  generate_changelog:
+    name: Generate Changelog
+    needs: release_prereq
+    uses: konveyor/release-tools/.github/workflows/generate-changelog.yml@main
+    with:
+      version: ${{ needs.release_prereq.outputs.tag_name }}
+      prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+      repository: ${{ github.repository }}
+      ref: ${{ github.sha }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   release:
     name: Final Release
     runs-on: ubuntu-latest
-    needs: release_prereq  
+    needs: [release_prereq, generate_changelog]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Download Changelog Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-artifact
+          path: ./artifacts
 
       - name: List available artifacts
         run: |
@@ -128,24 +142,12 @@ jobs:
           mv ./artifacts/vscode-extension-macos/*.vsix ./artifacts/konveyor-macos-${{ needs.release_prereq.outputs.tag_name }}.vsix
           mv ./artifacts/vscode-extension-windows/*.vsix ./artifacts/konveyor-windows-${{ needs.release_prereq.outputs.tag_name }}.vsix
 
-      # Reuse Konveyor changelog
-      - name: Generate Changelog
-        id: changelog
-        uses: konveyor/release-tools/create-release@main
-        with:
-          version: ${{ needs.release_prereq.outputs.tag_name }}
-          prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
-          repository: ${{ github.repository }}
-          ref: ${{ github.sha }}
-          skip_release: 'true'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.release_prereq.outputs.tag_name }}
           commit: ${{ github.sha }}
-          bodyFile: ${{ env.release_doc }}  
+          bodyFile: ./artifacts/release.md  
           artifacts: |
             ./artifacts/konveyor-linux-*.vsix
             ./artifacts/konveyor-macos-*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,14 +86,13 @@ jobs:
   generate_changelog:
     name: Generate Changelog
     needs: release_prereq
-    uses: konveyor/release-tools/.github/workflows/generate-changelog.yml@main
+    uses: savitharaghunathan/release-tools/.github/workflows/generate-changelog.yml@rel_flag
     with:
       version: ${{ needs.release_prereq.outputs.tag_name }}
       prev_version: $(gh api repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Final Release


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
